### PR TITLE
Fix "TypeError: object is not a function"

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,4 @@
 {
-  "presets": ["es2015"]
+  "presets": ["es2015"],
+  "plugins": ["add-module-exports"]
 }

--- a/dist/index.js
+++ b/dist/index.js
@@ -56,3 +56,5 @@ exports.default = function (robot) {
         });
     });
 };
+
+module.exports = exports['default'];

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "devDependencies": {
     "babel": "^6.3.26",
     "babel-core": "^6.4.0",
+    "babel-plugin-add-module-exports": "^0.2.1",
     "babel-preset-es2015": "^6.3.13",
     "gulp": "^3.9.0",
     "gulp-babel": "^6.1.1",


### PR DESCRIPTION
See https://www.npmjs.com/package/babel-plugin-add-module-exports. It's somewhat unfortunate that we're stuck using this, but we obviously can't change the way that Hubot loads the module, so this is what we're stuck with.

Fixes #4
